### PR TITLE
suggests 1:1 duration of 45 mins

### DIFF
--- a/docs/process/1-1s.md
+++ b/docs/process/1-1s.md
@@ -16,6 +16,7 @@ Every 1:1 at Flexpa must follow these procedural rules:
 
 * Must have a clearly defined format listed on this page – no phantom or unstructured 1:1s
 * Must be scheduled with a recurring calendar invite for the same time
+* Must be scheduled to have a duration of 45 mins - it's okay if the entire 45 mins isn't used but it's important that it is available if needed
 * Must have a calendar invite that includes one of the descriptions listed on this page
 * Must have a running 1:1 doc attached to the calendar invite
 * Must have an agenda written in the 1:1 in advance - which must be prepared by Flexpal reporting to their manager


### PR DESCRIPTION
## Why
* In my experience, 1:1s can feel quite rushed at a duration of 30 mins.
* Since increasing the 1:1 duration with my direct manager to 45 mins, I have noticed an increase in the quality of discussion since there is now more time to deeply unpack concepts.

## What
* In light of the above, this PR suggests standardising 1:1 duration to 45 mins.
* This is purely a suggestion and feedback/discussion is definitely welcome. Would equally be happy to close this without merging if it's deemed unfit for the OS.