### PR TITLE
feat(os): Added to steps to contribute and steps to run locally in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 1. Make a fork of the os repo. Currently only founders can merge directly to the main repo as we refine processes.
 2. Create a PR from your forked branch
 3. One of the founders will review your PR
-4. Merge!
+4. Address any updates
+5. A cofounder will merge when all checks have passed!
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # <img src="./docs/assets/logo-alt.png" height="60px" align="center" alt="Flexpa logo"> Flexpa Operating System
 
 ## Contributing to the OS
+0. When relevant, always seek feedback on a proposed update via a public Slack threads first, before committing to the OS. Discussions are more real-time and conducive via Slack.
 1. Make a fork of the os repo. Currently only founders can merge directly to the main repo as we refine processes.
 2. Create a PR from your forked branch
 3. One of the founders will review your PR

--- a/README.md
+++ b/README.md
@@ -1,5 +1,22 @@
 # <img src="./docs/assets/logo-alt.png" height="60px" align="center" alt="Flexpa logo"> Flexpa Operating System
 
+## Contributing to the OS
+1. Make a fork of the os repo. Currently only founders can merge directly to the main repo as we refine processes.
+2. Create a PR from your forked branch
+3. One of the founders will review your PR
+4. Merge!
+
+---
+
+## Running OS locally
+1. Install mkdocs with the following commands
+   1. `pip install mkdocs` or `brew install mkdocs`
+   2. `pip install mkdocs-material`
+   3. `pip install mkdocs-awesome-pages-plugin`
+2. Run `mkdocs serve`
+
+---
+
 ## Table of contents
 
 * [🪐 Operating System](docs/index.md)

--- a/docs/process/development.md
+++ b/docs/process/development.md
@@ -225,6 +225,16 @@ Details on pairing here.
 **Output**:  Ongoing notes. Action items on specific regulatory changes as needed.
 
 ### Ad-hoc
+<<<<<<< Updated upstream
+=======
+#### Design review & scoping
+* **Duration**: As long as it takes (typically starting with 90 minutes)
+
+**Purpose**: To denmark the end of large scope design work for a project (small tweaks, edge cases, etc can still be flushed out after meeting), and review user flows and questions with wider product team. It is expected that intermittent discussions and reviews with the product and technical teams take place prior to this meeting via Figma comments or Slack threads. However, there is still a time when development needs to start, and a formal review meeting with the relevant parties is called. To make the most of this meeting, designer should resolve as many questions as possible via Figma comments, slack discussions, and individual research ahead of time, and reserve synchronous time to meatier discussions.
+
+**Output**: Scoping decisions on work with a rough outline of Milestones. It's possible, if the team feels ready, that the first Milestone meeting takes place during this session, pending attendee discussion and decisions.
+
+>>>>>>> Stashed changes
 #### Milestone planning
 * **Duration**: As long as it takes (typically starting with 60 minutes)
 


### PR DESCRIPTION
**Why**
When contributing to the OS I realized I didn't know how to run the repo locally. Team assisted via a Slack message. This is a good opportunity to add the process to the readme for future Flexpals to reference as well.

**What**
1. Added steps to contribute to the readme
2. Added steps to run the os locally