### PR TITLE
Standup note update

### DIFF
--- a/docs/process/standups.md
+++ b/docs/process/standups.md
@@ -2,18 +2,22 @@
 
 ## Goal
 
-Communicate status/progress and write down our goals for every day.
+Being [remote first](./remote-first.md) means we don't have the luxury of being able to see each other in person every day. We need to find other ways to communicate not just our progress and goals but also how we're feeling and what's going on in our lives.
 
 ## Process
 
-Use the #standups channel on Slack.
+Our standup process is asynchronous. We use the #standups channel on Slack.
 
 Every morning by 10AM local time post your standup note (you can do this in advance if you post at the end of the previous day).
 
-A standup note should consist of up to five bullet points:
+To write a standup note, ask yourself the following questions and post your responses:
 
-* How are you feeling out of 10
+* How am I feeling out of 10?
 * What am I focussed on today?
-* What am I blocked on? (tag people)
-* Notes about availability (i.e "busy from 2pm to 4pm")
-* Something you are grateful for today
+  * What is the most important thing I get done?
+  * Am I blocked?
+  * Am I going to be unavailable? (i.e "Have an important meeting at 2PM, won't be responsive")
+* What can I share about myself?
+  * Am I grateful for something today?
+  * What's my favorite thing to do outside of work?
+  * What did I dream of doing as a kid?


### PR DESCRIPTION
## Why
* At our last retreat, we discussed opening up the scope of our "grateful for" note in standups. We discussed that the purpose of our standups wasn't just to communicate status, but to give us a daily mechanism to build relationships together by getting to know each other. 

## What
* Captures the goal of using standups to communicate status but also how we're feeling and what's going on in our lives
* Expands the scope of the last standup point to be "What can I share about myself" - gratitude notes are still a way to answer this question, but other prompts can be just as useful